### PR TITLE
Integrate Pino library

### DIFF
--- a/bufflog.ts
+++ b/bufflog.ts
@@ -1,8 +1,41 @@
 
 export class BuffLog {
-    name: string;
+    pinoLogger: any;
+    defaultLevel = 'notice';
 
     constructor() {
-        this.name = "toto";
+        this.pinoLogger = require('pino')({
+            'level': this.defaultLevel,
+            // notice doesn't exist in pino, let's add it
+            customLevels: {
+                notice: 35
+              }
+        });
     }
+
+    debug(message: string) {
+        this.pinoLogger.debug(message);
+    }
+
+    info(message: string) {
+        this.pinoLogger.info(message);
+    }
+
+    notice(message: string) {
+        this.pinoLogger.notice(message);
+    }
+
+    warning(message: string) {
+        this.pinoLogger.warn(message);
+    }
+
+    error(message: string) {
+        this.pinoLogger.error(message);
+    }
+
+    // for consistency with php-bufflog, critical == fatal
+    critical(message: string) {
+        this.pinoLogger.fatal(message);
+    }
+
 }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,10 @@
 import {BuffLog} from './bufflog';
 
-let log = new BuffLog();
-console.log(log);
+let logger = new BuffLog();
+
+logger.info('hello info');
+logger.debug('hello debug');
+logger.notice('hello notice');
+logger.warning('hello warning');
+logger.error('hello error');
+logger.critical('hello critical');


### PR DESCRIPTION
Use [pino-js](https://github.com/pinojs/pino) logging library 

I've written directly the method name in the `BuffLog` class. Something I'm still considering: 
- I was thinking to use [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) (equivalent to the `__call` method in PHP) to call punoJS directly , but I'm unsure on how other javascript services will support since it's only supported since `ES6`.  
- Perhaps "extends" the pino-js class. but not too sure how to do it, but if it's something possible, that could be a better design (sorry still trying to get my  JS/TS up-to-speed) 

I've also kept the function naming consistency with [`php-bufflog`](https://github.com/bufferapp/php-bufflog): 
- `warn` => `warning`
- `fatal` => `critical`
- `notice` doesn't exist, so i've created it. 

More PRs coming for logging level,  data structure, traces & co

Can I have your quick eyes on this @esclapes @colinscape ?  Merging it for now, but I'll consider  any feedbacks to make this right