### PR TITLE
Make compatible es6 and CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ logger for all javascript and typescript Buffer services
 ```js
 
 // CommonJS style
-const BuffLog = require('./bufflog');
+const BuffLog = require('bufflog');
 
 // ES6 style
-import * as BuffLog  from "./bufflog";
+import * as BuffLog  from "bufflog";
 
 BuffLog.debug('hello critical', {"some":"stuff"});
 BuffLog.info('hello info');

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ logger for all javascript and typescript Buffer services
 ## Usage
 ```js
 
-// ES6: 
-import { BuffLog } from 'BuffLog';
+// CommonJS style
+const BuffLog = require('./bufflog');
 
-// const BuffLog = require('@bufferapp/bufflog').BuffLog
+// ES6 style
+import * as BuffLog  from "./bufflog";
 
 BuffLog.debug('hello critical', {"some":"stuff"});
 BuffLog.info('hello info');

--- a/bufflog.ts
+++ b/bufflog.ts
@@ -13,30 +13,27 @@ const pinoLogger = require('pino')({
       }
 });
 
-export class BuffLog {
+export function debug(message: string, context?: object) {
+    pinoLogger.debug({context: context}, message);
+}
 
-    static debug(message: string, context?: object) {
-        pinoLogger.debug({context: context}, message);
-    }
+export function info(message: string, context?: object) {
+    pinoLogger.info({context: context}, message);
+}
 
-    static info(message: string, context?: object) {
-        pinoLogger.info({context: context}, message);
-    }
+export function notice(message: string, context?: object) {
+    pinoLogger.notice({context: context}, message);
+}
 
-    static notice(message: string, context?: object) {
-        pinoLogger.notice({context: context}, message);
-    }
+export function warning(message: string, context?: object) {
+    pinoLogger.warn({context: context}, message);
+}
 
-    static warning(message: string, context?: object) {
-        pinoLogger.warn({context: context}, message);
-    }
+export function error(message: string, context?: object) {
+    pinoLogger.error({context: context}, message);
+}
 
-    static error(message: string, context?: object) {
-        pinoLogger.error({context: context}, message);
-    }
-
-    // for consistency with php-bufflog, critical == fatal
-    static critical(message: string, context?: object) {
-        pinoLogger.fatal({context: context}, message);
-    }
+// for consistency with php-bufflog, critical == fatal
+export function critical(message: string, context?: object) {
+    pinoLogger.fatal({context: context}, message);
 }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,11 @@
 import tracer from "dd-trace";
 import express from 'express';
-import { BuffLog } from './bufflog';
+
+// CommonJS style
+//const BuffLog = require('./bufflog');
+
+// ES6 style
+import * as BuffLog  from "./bufflog";
 
 tracer.init({
     hostname: "dd-agent-hostname",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "bufflog",
-  "version": "0.0.1",
+  "name": "@bufferapp/bufflog",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "logger for all javascript and typescript Buffer services",
   "main": "dist/bufflog.js",
   "scripts": {


### PR DESCRIPTION
`class` , `static` and `export` were introduced in `ES6`

Unfortunately , most of our projects are incompatible with ES6 module, or would require `babel` to import the library properly. What isn't ideal if we want it used widely in all our current js services. 

This transformation is a compromise to make the library works for most of our js services. It's obviously less elegant, but works most of the time.

```js
// CommonJS style
const BuffLog = require('bufflog');

// ES6 style
import * as BuffLog  from "bufflog";

// will be able to use: 
BuffLog.notice('hello notice');
BuffLog.info('hello info');
BuffLog.notice('hello notice with context', {"test":"toto"});
BuffLog.warning('hello warning');
```

@colinscape @esclapes up for a review?