### PR TITLE
BuffLog middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ tracer.init({
     // ... all other options...
 });
 ```
+
+## Use bufflog middleware with express
+```js
+const app = express();
+app.use(BuffLog.middleware())
+```

--- a/bufflog.ts
+++ b/bufflog.ts
@@ -48,3 +48,9 @@ export function error(message: string, context?: object) {
 export function critical(message: string, context?: object) {
     pinoLogger.fatal({context: context}, message);
 }
+
+export function middleware() {
+    return require('pino-http')({
+       logger: pinoLogger
+   })
+}

--- a/bufflog.ts
+++ b/bufflog.ts
@@ -51,6 +51,17 @@ export function critical(message: string, context?: object) {
 
 export function middleware() {
     return require('pino-http')({
-       logger: pinoLogger
+       logger: pinoLogger,
+
+    // Define a custom logger level
+    customLogLevel: function (res: any, err: any) {
+        if (res.statusCode >= 400 && res.statusCode < 500) {
+            // for now, we don't want notice notification on the 4xx
+            return 'info'
+        } else if (res.statusCode >= 500 || err) {
+           return 'error'
+        }
+        return 'info'
+    },
    })
 }

--- a/bufflog.ts
+++ b/bufflog.ts
@@ -20,6 +20,10 @@ const pinoLogger = require('pino')({
 
 });
 
+export function getLogger() {
+    return pinoLogger;
+}
+
 export function debug(message: string, context?: object) {
     pinoLogger.debug({context: context}, message);
 }

--- a/index.ts
+++ b/index.ts
@@ -38,5 +38,19 @@ app.get('/', (req, res) =>  {
     BuffLog.warning('hello warning');
     BuffLog.error('hello error');
     BuffLog.critical('hello critical');
-    res.send({})
+    res.send({'hello': 'world'})
+});
+
+app.get('/error500', (req, res) =>  {
+    BuffLog.critical('hello critical');
+    return res.status(500).send({
+        message: 'This is an error 500!'
+     });
+});
+
+app.get('/error404', (req, res) =>  {
+    BuffLog.critical('hello critical');
+    return res.status(404).send({
+        message: 'This is a 404!'
+     });
 });

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,8 @@ BuffLog.critical('hello critical', {"some":"stuff"});
 
 const app = express();
 
+app.use(BuffLog.middleware())
+
 app.listen(4000, () => {
     console.log(`Server is listening on port 4000`);
 });
@@ -36,4 +38,5 @@ app.get('/', (req, res) =>  {
     BuffLog.warning('hello warning');
     BuffLog.error('hello error');
     BuffLog.critical('hello critical');
+    res.send({})
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -109,6 +109,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "base64-js": {
       "version": "1.3.1",
@@ -348,6 +353,14 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "requires": {
+        "punycode": "^1.3.2"
+      }
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -751,6 +764,45 @@
         "sonic-boom": "^0.7.5"
       }
     },
+    "pino-http": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.0.0.tgz",
+      "integrity": "sha512-1D64WYIS6j1GouDrI3a3n60GGV8Fvp4sXIeYAD+atg/qneZxmzOlWpQoDphgjeeEEIRUG0JMol0bJ5vMU3Zk5Q==",
+      "requires": {
+        "fast-url-parser": "^1.1.3",
+        "pino": "^6.0.0",
+        "pino-std-serializers": "^2.4.0"
+      },
+      "dependencies": {
+        "pino": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.1.1.tgz",
+          "integrity": "sha512-enLaR5hDiiegrbh5q4vfiO9aaNrG8EDB7vfPihEmQ/TfLBacnkV3mw2RikAm16UE4OQahnw1en0j/B3+ypNImA==",
+          "requires": {
+            "fast-redact": "^2.0.0",
+            "fast-safe-stringify": "^2.0.7",
+            "flatstr": "^1.0.12",
+            "pino-std-serializers": "^2.4.2",
+            "quick-format-unescaped": "^4.0.1",
+            "sonic-boom": "^1.0.0"
+          }
+        },
+        "quick-format-unescaped": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+          "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
+        },
+        "sonic-boom": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.1.tgz",
+          "integrity": "sha512-o9tx+bonVEXSaPtptyXQXpP8l6UV9Bi3im2geZskvWw2a/o/hrbWI7EBbbv+rOx6Hubnzun9GgH4WfbgEA3MFQ==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "flatstr": "^1.0.12"
+          }
+        }
+      }
+    },
     "pino-std-serializers": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
@@ -765,6 +817,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
       }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@types/pino": "^5.15.5",
     "dd-trace": "^0.18.0",
-    "pino": "^5.16.0"
+    "pino": "^5.16.0",
+    "pino-http": "^5.0.0"
   },
   "types": "dist/bufflog.d.ts",
   "prepublish": "./node_modules/typescript/bin/tsc"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "logger for all javascript and typescript Buffer services",
   "main": "dist/bufflog.js",
   "scripts": {


### PR DESCRIPTION
In order to replace the previous [`@bufferapp/middleware`](https://github.com/bufferapp/buffer-js-logger/blob/master/middleware.js)

- Add `getLogger` to be able to use the `pino` instance
- Ddd the `middleware()` function  (use [`pino-http`](https://github.com/pinojs/pino-http) under the hood)

Usage: 
```js
const app = express();
app.use(BuffLog.middleware())
```

or if we want to use the logger instance instead to personalise how the middleware works : 
```js 
const app = express();
const middlewareLogger = require('pino-http')({
  logger: bufflog.getLogger(),
 // ... options
})
app.use(middlewareLogger)
```

the output looks like this: 
```
{
    "dd": {
        "span_id": "6047504131036872311",
        "trace_id": "6047504131036872311"
    },
    "level": 200,
    "message": "request completed",
    "req": {
        "headers": {
            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
            "accept-encoding": "gzip, deflate, br",
            "accept-language": "en-US,en;q=0.9,fr;q=0.8,zh-TW;q=0.7,zh;q=0.6",
            "cache-control": "max-age=0",
            "connection": "keep-alive",
            "host": "localhost:4000",
            "if-none-match": "W/\"11-IkjuL6CqqtmReFMfkkvwC0sKj04\"",
            "sec-fetch-dest": "document",
            "sec-fetch-mode": "navigate",
            "sec-fetch-site": "cross-site",
            "sec-fetch-user": "?1",
            "upgrade-insecure-requests": "1",
            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
        },
        "id": 1,
        "method": "GET",
        "remoteAddress": "::1",
        "remotePort": 61841,
        "url": "/"
    },
    "res": {
        "headers": {
            "etag": "W/\"11-IkjuL6CqqtmReFMfkkvwC0sKj04\"",
            "x-powered-by": "Express"
        },
        "statusCode": 304
    },
    "responseTime": 10,
    "time": 1586254897546,
    "v": 1
}
```


There was also many stats calculated in the previous loggers. I feel like those should be aimed to be in the APM tracking instead of the logs. 



@esclapes  up for a review? 
