### PR TITLE
Optional parameter to the middleware

### DIFF
--- a/bufflog.ts
+++ b/bufflog.ts
@@ -1,3 +1,5 @@
+import  { Options }  from "pino-http";
+
 const pinoLogger = require('pino')({
     level: process.env.LOG_LEVEL ? String.prototype.toLowerCase.apply(process.env.LOG_LEVEL) : "notice",
     // probably we want to call it `msg`. if so, let's change the PHP library instead
@@ -49,19 +51,24 @@ export function critical(message: string, context?: object) {
     pinoLogger.fatal({context: context}, message);
 }
 
-export function middleware() {
-    return require('pino-http')({
-       logger: pinoLogger,
+export function middleware(options?: Options) {
 
-    // Define a custom logger level
-    customLogLevel: function (res: any, err: any) {
-        if (res.statusCode >= 400 && res.statusCode < 500) {
-            // for now, we don't want notice notification on the 4xx
+    // be aware of the non-null assertion operator:  https://stackoverflow.com/a/57062363
+    const {  logger, genReqId, useLevel, stream, autoLogging, customLogLevel  } : Options = options || {};
+
+    return require('pino-http')({
+       logger: logger || pinoLogger,
+       autoLogging: autoLogging || true,
+
+        // Define a custom logger level
+        customLogLevel: customLogLevel || function (res: any, err: any) {
+            if (res.statusCode >= 400 && res.statusCode < 500) {
+                // for now, we don't want notice notification on the 4xx
+                return 'info'
+            } else if (res.statusCode >= 500 || err) {
+            return 'error'
+            }
             return 'info'
-        } else if (res.statusCode >= 500 || err) {
-           return 'error'
-        }
-        return 'info'
-    },
+        },
    })
 }

--- a/bufflog.ts
+++ b/bufflog.ts
@@ -53,12 +53,10 @@ export function critical(message: string, context?: object) {
 
 export function middleware(options?: Options) {
 
-    // be aware of the non-null assertion operator:  https://stackoverflow.com/a/57062363
     const {  logger, genReqId, useLevel, stream, autoLogging, customLogLevel  } : Options = options || {};
 
     return require('pino-http')({
        logger: logger || pinoLogger,
-       autoLogging: autoLogging || true,
 
         // Define a custom logger level
         customLogLevel: customLogLevel || function (res: any, err: any) {

--- a/index.ts
+++ b/index.ts
@@ -24,7 +24,11 @@ BuffLog.critical('hello critical', {"some":"stuff"});
 
 const app = express();
 
-app.use(BuffLog.middleware())
+ app.use(BuffLog.middleware())
+
+// use custom parameter , here a pino logger
+ app.use(BuffLog.middleware({'logger': require('pino')()}))
+
 
 app.listen(4000, () => {
     console.log(`Server is listening on port 4000`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -63,6 +63,14 @@
         "@types/node": "*",
         "@types/pino-std-serializers": "*",
         "@types/sonic-boom": "*"
+      }
+    },
+    "@types/pino-http": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-4.4.0.tgz",
+      "integrity": "sha512-KZH4QW3Z82BAFBfYzGHwA/5S4xmqN4i3FcheY3AjDj3402vUgGG0KgYqODU/KfFUd39uYEXHz4CJYVN7512vvA==",
+      "requires": {
+        "@types/pino": "*"
       }
     },
     "@types/pino-std-serializers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "logger for all javascript and typescript Buffer services",
   "main": "dist/bufflog.js",
   "scripts": {
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@types/pino": "^5.15.5",
+    "@types/pino-http": "^4.4.0",
     "dd-trace": "^0.18.0",
     "pino": "^5.16.0",
     "pino-http": "^5.0.0"


### PR DESCRIPTION
Allow to pass optional parameters to the middleware.
For now, only allow `logger` and `customLogLevel` option

```js
// eg: a custom logger: 
var pino = require('pino');
 app.use(BuffLog.middleware({'logger': pino()}))

// customLevels
var myLevels = function (res: any, err: any) {
            if (res.statusCode >= 400 && res.statusCode < 500) {
                return 'notice'
            } else if (res.statusCode >= 500 || err) {
                return 'critical'
            }
            return 'debug'
        }

 app.use(BuffLog.middleware({'customLogLevel': myLevels )}))

// or both : 
 app.use(BuffLog.middleware({'customLogLevel': myLevels, 'logger': pino() )}))
```

### What I'm unsure: 
Here my non-js expertise that talks : 

For the [others options](https://github.com/pinojs/pino-http#api), I didn't do it  (yet) since it feels like copy pasting the [code of  the `pino-http` itself](https://github.com/pinojs/pino-http/blob/57fc852d35ced806100a1cbb1fdddece22f049e0/logger.js#L16-L56) .

I'm wondering if there is not a way to not copy paste., and simply forwarding the defaults ? 

Thoughts  @esclapes   @colinscape ?