### PR TITLE
Use named export for easier usage and auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ logger for all javascript and typescript Buffer services
 ```js
 
 // CommonJS style
-const bufflog = require('@bufferapp/bufflog');
+const Bufflog = require('@bufferapp/bufflog');
 
 // ES6 style
-import * as bufflog  from "@bufferapp/bufflog";
+import Bufflog  from "@bufferapp/bufflog";
 
-bufflog.debug('hello critical', {"some":"stuff"});
-bufflog.info('hello info');
-bufflog.notice('hello notice with context', {"foo":"bar"});
-bufflog.error('hello error');
-bufflog.critical('hello critical');
+Bufflog.debug('hello critical', {"some":"stuff"});
+Bufflog.info('hello info');
+Bufflog.notice('hello notice with context', {"foo":"bar"});
+Bufflog.error('hello error');
+Bufflog.critical('hello critical');
 ```
 
 ## Log verbosity levels
@@ -57,5 +57,5 @@ tracer.init({
 ## Use bufflog middleware with express
 ```js
 const app = express();
-app.use(bufflog.middleware())
+app.use(Bufflog.middleware())
 ```

--- a/bufflog.ts
+++ b/bufflog.ts
@@ -16,7 +16,7 @@ const pinoLogger = require('pino')({
         fatal: 500
       },
       // necessary if we want to override the level "number"
-      useOnlyCustomLevels: true, 
+      useOnlyCustomLevels: true,
 
 });
 
@@ -65,3 +65,16 @@ export function middleware() {
     },
    })
 }
+
+const BuffLog = {
+    getLogger,
+    debug,
+    info,
+    notice,
+    warning,
+    error,
+    critical,
+    middleware,
+}
+
+export default BuffLog

--- a/index.ts
+++ b/index.ts
@@ -2,10 +2,10 @@ import tracer from "dd-trace";
 import express from 'express';
 
 // CommonJS style
-//const BuffLog = require('./bufflog');
+// const BuffLog = require('./bufflog');
 
 // ES6 style
-import * as BuffLog  from "./bufflog";
+import BuffLog from "./bufflog";
 
 tracer.init({
     hostname: "dd-agent-hostname",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "logger for all javascript and typescript Buffer services",
   "main": "dist/bufflog.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/bufflog",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "logger for all javascript and typescript Buffer services",
   "main": "dist/bufflog.js",
   "scripts": {


### PR DESCRIPTION
Use named export for easier usage and auto-completion : no more `import * as Bufflog` 🙌 